### PR TITLE
Fix Finnish features page screenshots and translations

### DIFF
--- a/src/app/[locale]/features/page.tsx
+++ b/src/app/[locale]/features/page.tsx
@@ -1,14 +1,59 @@
 'use client';
 
 import Image from 'next/image';
-import { ArrowRight, Target, BarChart3, Users, Zap, Wifi, Smartphone, Shield, Clock, Trophy, Settings, Calendar, Download, Star } from 'lucide-react';
+import {
+  ArrowRight,
+  Target,
+  BarChart3,
+  Users,
+  Zap,
+  Wifi,
+  Smartphone,
+  Shield,
+  Clock,
+  Trophy,
+  Settings,
+  Calendar,
+  Download,
+  Star,
+  type LucideIcon
+} from 'lucide-react';
 import { useI18n } from '@/locales/client';
-import { Button, Container, Section, Card, CardIcon, CardTitle, CardDescription } from '@/components/ui';
+import {
+  Button,
+  Container,
+  Section,
+  Card,
+  CardIcon,
+  CardTitle,
+  CardDescription
+} from '@/components/ui';
+
+type TFunction = ReturnType<typeof useI18n>;
+type TranslationKey = Parameters<TFunction>[0];
+
+type Feature = {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+  benefits: TranslationKey[];
+  image?: string;
+  caption: TranslationKey;
+};
+
+type FeatureCategory = {
+  id: string;
+  title: string;
+  description: string;
+  icon: LucideIcon;
+  color: 'cyan' | 'lime' | 'violet';
+  features: Feature[];
+};
 
 export default function FeaturesPage() {
   const t = useI18n();
 
-  const featureCategories = [
+  const featureCategories: FeatureCategory[] = [
     {
       id: 'tactics',
       title: t('features.categories.tactics'),
@@ -20,17 +65,17 @@ export default function FeaturesPage() {
           icon: Settings,
           title: t('features.tactics.playerPositioning.title'),
           description: t('features.tactics.playerPositioning.description'),
-          benefits: ['features.tactics.playerPositioning.benefits.0', 'features.tactics.playerPositioning.benefits.1', 'features.tactics.playerPositioning.benefits.2', 'features.tactics.playerPositioning.benefits.3'],
+          benefits: ['features.tactics.playerPositioning.benefits.0', 'features.tactics.playerPositioning.benefits.1', 'features.tactics.playerPositioning.benefits.2', 'features.tactics.playerPositioning.benefits.3'] as TranslationKey[],
           image: '/features/player-positioning-live-match.png',
-          caption: 'features.tactics.playerPositioning.caption'
+          caption: 'features.tactics.playerPositioning.caption' as TranslationKey
         },
         {
           icon: Target,
           title: t('features.tactics.tacticalDrawing.title'),
           description: t('features.tactics.tacticalDrawing.description'),
-          benefits: ['features.tactics.tacticalDrawing.benefits.0', 'features.tactics.tacticalDrawing.benefits.1', 'features.tactics.tacticalDrawing.benefits.2', 'features.tactics.tacticalDrawing.benefits.3'],
+          benefits: ['features.tactics.tacticalDrawing.benefits.0', 'features.tactics.tacticalDrawing.benefits.1', 'features.tactics.tacticalDrawing.benefits.2', 'features.tactics.tacticalDrawing.benefits.3'] as TranslationKey[],
           image: '/features/tactical-drawing-board.png',
-          caption: 'features.tactics.tacticalDrawing.caption'
+          caption: 'features.tactics.tacticalDrawing.caption' as TranslationKey
         }
       ]
     },
@@ -45,25 +90,25 @@ export default function FeaturesPage() {
           icon: BarChart3,
           title: t('features.statistics.competitionStats.title'),
           description: t('features.statistics.competitionStats.description'),
-          benefits: ['features.statistics.competitionStats.benefits.0', 'features.statistics.competitionStats.benefits.1', 'features.statistics.competitionStats.benefits.2', 'features.statistics.competitionStats.benefits.3'],
+          benefits: ['features.statistics.competitionStats.benefits.0', 'features.statistics.competitionStats.benefits.1', 'features.statistics.competitionStats.benefits.2', 'features.statistics.competitionStats.benefits.3'] as TranslationKey[],
           image: '/features/competition-statistics.png',
-          caption: 'features.statistics.competitionStats.caption'
+          caption: 'features.statistics.competitionStats.caption' as TranslationKey
         },
         {
           icon: Trophy,
           title: t('features.statistics.playerAnalysis.title'),
           description: t('features.statistics.playerAnalysis.description'),
-          benefits: ['features.statistics.playerAnalysis.benefits.0', 'features.statistics.playerAnalysis.benefits.1', 'features.statistics.playerAnalysis.benefits.2', 'features.statistics.playerAnalysis.benefits.3'],
+          benefits: ['features.statistics.playerAnalysis.benefits.0', 'features.statistics.playerAnalysis.benefits.1', 'features.statistics.playerAnalysis.benefits.2', 'features.statistics.playerAnalysis.benefits.3'] as TranslationKey[],
           image: '/features/player-performance-analysis.png',
-          caption: 'features.statistics.playerAnalysis.caption'
+          caption: 'features.statistics.playerAnalysis.caption' as TranslationKey
         },
         {
           icon: Clock,
           title: t('features.statistics.liveTracking.title'),
           description: t('features.statistics.liveTracking.description'),
-          benefits: ['features.statistics.liveTracking.benefits.0', 'features.statistics.liveTracking.benefits.1', 'features.statistics.liveTracking.benefits.2', 'features.statistics.liveTracking.benefits.3'],
+          benefits: ['features.statistics.liveTracking.benefits.0', 'features.statistics.liveTracking.benefits.1', 'features.statistics.liveTracking.benefits.2', 'features.statistics.liveTracking.benefits.3'] as TranslationKey[],
           image: '/features/live-game-tracking.png',
-          caption: 'features.statistics.liveTracking.caption'
+          caption: 'features.statistics.liveTracking.caption' as TranslationKey
         }
       ]
     },
@@ -78,37 +123,37 @@ export default function FeaturesPage() {
           icon: Users,
           title: t('features.management.teamRoster.title'),
           description: t('features.management.teamRoster.description'),
-          benefits: ['features.management.teamRoster.benefits.0', 'features.management.teamRoster.benefits.1', 'features.management.teamRoster.benefits.2', 'features.management.teamRoster.benefits.3'],
+          benefits: ['features.management.teamRoster.benefits.0', 'features.management.teamRoster.benefits.1', 'features.management.teamRoster.benefits.2', 'features.management.teamRoster.benefits.3'] as TranslationKey[],
           image: '/screenshots/team and roster management feature.png',
-          caption: 'features.management.teamRoster.caption'
+          caption: 'features.management.teamRoster.caption' as TranslationKey
         },
         {
           icon: Calendar,
           title: t('features.management.seasonTournament.title'),
           description: t('features.management.seasonTournament.description'),
-          benefits: ['features.management.seasonTournament.benefits.0', 'features.management.seasonTournament.benefits.1', 'features.management.seasonTournament.benefits.2', 'features.management.seasonTournament.benefits.3'],
+          benefits: ['features.management.seasonTournament.benefits.0', 'features.management.seasonTournament.benefits.1', 'features.management.seasonTournament.benefits.2', 'features.management.seasonTournament.benefits.3'] as TranslationKey[],
           image: '/screenshots/seasonandtournamentmanagement.png',
-          caption: 'features.management.seasonTournament.caption'
+          caption: 'features.management.seasonTournament.caption' as TranslationKey
         },
         {
           icon: Shield,
           title: t('features.management.gameStorage.title'),
           description: t('features.management.gameStorage.description'),
-          benefits: ['features.management.gameStorage.benefits.0', 'features.management.gameStorage.benefits.1', 'features.management.gameStorage.benefits.2', 'features.management.gameStorage.benefits.3'],
+          benefits: ['features.management.gameStorage.benefits.0', 'features.management.gameStorage.benefits.1', 'features.management.gameStorage.benefits.2', 'features.management.gameStorage.benefits.3'] as TranslationKey[],
           image: '/screenshots/Saver and load gamespng.png',
-          caption: 'features.management.gameStorage.caption'
+          caption: 'features.management.gameStorage.caption' as TranslationKey
         },
         {
           icon: Star,
           title: t('features.management.playerAssessment.title'),
           description: t('features.management.playerAssessment.description'),
-          benefits: ['features.management.playerAssessment.benefits.0', 'features.management.playerAssessment.benefits.1', 'features.management.playerAssessment.benefits.2', 'features.management.playerAssessment.benefits.3'],
+          benefits: ['features.management.playerAssessment.benefits.0', 'features.management.playerAssessment.benefits.1', 'features.management.playerAssessment.benefits.2', 'features.management.playerAssessment.benefits.3'] as TranslationKey[],
           image: '/screenshots/palyerassesments.png',
-          caption: 'features.management.playerAssessment.caption'
+          caption: 'features.management.playerAssessment.caption' as TranslationKey
         }
       ]
     }
-  ] as const;
+  ];
 
   const getColorClasses = (color: string) => {
     const colors = {

--- a/src/app/[locale]/features/page.tsx
+++ b/src/app/[locale]/features/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import { ArrowRight, Target, BarChart3, Users, Zap, Wifi, Smartphone, Shield, Clock, Trophy, Settings, Calendar, Download, Upload, Star } from 'lucide-react';
+import { ArrowRight, Target, BarChart3, Users, Zap, Wifi, Smartphone, Shield, Clock, Trophy, Settings, Calendar, Download, Star } from 'lucide-react';
 import { useI18n } from '@/locales/client';
 import { Button, Container, Section, Card, CardIcon, CardTitle, CardDescription } from '@/components/ui';
 
@@ -21,14 +21,16 @@ export default function FeaturesPage() {
           title: t('features.tactics.playerPositioning.title'),
           description: t('features.tactics.playerPositioning.description'),
           benefits: ['features.tactics.playerPositioning.benefits.0', 'features.tactics.playerPositioning.benefits.1', 'features.tactics.playerPositioning.benefits.2', 'features.tactics.playerPositioning.benefits.3'],
-          image: '/features/formations.png'
+          image: '/features/player-positioning-live-match.png',
+          caption: 'features.tactics.playerPositioning.caption'
         },
         {
           icon: Target,
           title: t('features.tactics.tacticalDrawing.title'),
           description: t('features.tactics.tacticalDrawing.description'),
           benefits: ['features.tactics.tacticalDrawing.benefits.0', 'features.tactics.tacticalDrawing.benefits.1', 'features.tactics.tacticalDrawing.benefits.2', 'features.tactics.tacticalDrawing.benefits.3'],
-          image: '/features/tactical-field.png'
+          image: '/features/tactical-drawing-board.png',
+          caption: 'features.tactics.tacticalDrawing.caption'
         }
       ]
     },
@@ -44,21 +46,24 @@ export default function FeaturesPage() {
           title: t('features.statistics.competitionStats.title'),
           description: t('features.statistics.competitionStats.description'),
           benefits: ['features.statistics.competitionStats.benefits.0', 'features.statistics.competitionStats.benefits.1', 'features.statistics.competitionStats.benefits.2', 'features.statistics.competitionStats.benefits.3'],
-          image: '/features/season-stats.png'
+          image: '/features/competition-statistics.png',
+          caption: 'features.statistics.competitionStats.caption'
         },
         {
           icon: Trophy,
           title: t('features.statistics.playerAnalysis.title'),
           description: t('features.statistics.playerAnalysis.description'),
           benefits: ['features.statistics.playerAnalysis.benefits.0', 'features.statistics.playerAnalysis.benefits.1', 'features.statistics.playerAnalysis.benefits.2', 'features.statistics.playerAnalysis.benefits.3'],
-          image: '/features/player-analysis.png'
+          image: '/features/player-performance-analysis.png',
+          caption: 'features.statistics.playerAnalysis.caption'
         },
         {
           icon: Clock,
           title: t('features.statistics.liveTracking.title'),
           description: t('features.statistics.liveTracking.description'),
           benefits: ['features.statistics.liveTracking.benefits.0', 'features.statistics.liveTracking.benefits.1', 'features.statistics.liveTracking.benefits.2', 'features.statistics.liveTracking.benefits.3'],
-          image: '/features/live-tracking.png'
+          image: '/features/live-game-tracking.png',
+          caption: 'features.statistics.liveTracking.caption'
         }
       ]
     },
@@ -74,28 +79,32 @@ export default function FeaturesPage() {
           title: t('features.management.teamRoster.title'),
           description: t('features.management.teamRoster.description'),
           benefits: ['features.management.teamRoster.benefits.0', 'features.management.teamRoster.benefits.1', 'features.management.teamRoster.benefits.2', 'features.management.teamRoster.benefits.3'],
-          image: '/screenshots/team and roster management feature.png'
+          image: '/screenshots/team and roster management feature.png',
+          caption: 'features.management.teamRoster.caption'
         },
         {
           icon: Calendar,
           title: t('features.management.seasonTournament.title'),
           description: t('features.management.seasonTournament.description'),
           benefits: ['features.management.seasonTournament.benefits.0', 'features.management.seasonTournament.benefits.1', 'features.management.seasonTournament.benefits.2', 'features.management.seasonTournament.benefits.3'],
-          image: '/screenshots/seasonandtournamentmanagement.png'
+          image: '/screenshots/seasonandtournamentmanagement.png',
+          caption: 'features.management.seasonTournament.caption'
         },
         {
           icon: Shield,
           title: t('features.management.gameStorage.title'),
           description: t('features.management.gameStorage.description'),
           benefits: ['features.management.gameStorage.benefits.0', 'features.management.gameStorage.benefits.1', 'features.management.gameStorage.benefits.2', 'features.management.gameStorage.benefits.3'],
-          image: '/screenshots/Saver and load gamespng.png'
+          image: '/screenshots/Saver and load gamespng.png',
+          caption: 'features.management.gameStorage.caption'
         },
         {
           icon: Star,
           title: t('features.management.playerAssessment.title'),
           description: t('features.management.playerAssessment.description'),
           benefits: ['features.management.playerAssessment.benefits.0', 'features.management.playerAssessment.benefits.1', 'features.management.playerAssessment.benefits.2', 'features.management.playerAssessment.benefits.3'],
-          image: '/screenshots/palyerassesments.png'
+          image: '/screenshots/palyerassesments.png',
+          caption: 'features.management.playerAssessment.caption'
         }
       ]
     }
@@ -204,148 +213,20 @@ export default function FeaturesPage() {
 
                   {/* Feature Image */}
                   <div className={`${index % 2 === 1 ? 'lg:col-start-1 lg:row-start-1' : ''}`}>
-                    {feature.title === 'Player Positioning' ? (
+                    {feature.image ? (
                       <div className="flex justify-center">
                         <div className="bg-slate-800/50 backdrop-blur-sm border border-slate-700/50 rounded-2xl p-4 group hover:border-slate-600/50 transition-colors duration-300">
                           <div className="bg-black rounded-xl overflow-hidden w-72 mx-auto">
-                            <Image 
-                              src="/features/player-positioning-live-match.png" 
-                              alt="MatchOps Local player positioning interface showing live match between Kultsa and PePo Purppura with real-time player positions"
+                            <Image
+                              src={feature.image}
+                              alt={t(feature.caption)}
                               width={288}
                               height={624}
                               className="w-full h-auto block"
                               style={{ imageRendering: 'crisp-edges' }}
                             />
                           </div>
-                          <p className="text-slate-300 text-xs mt-2 text-center font-body">{t('features.tactics.playerPositioning.caption')}</p>
-                        </div>
-                      </div>
-                    ) : feature.title === 'Tactical Drawing Board' ? (
-                      <div className="flex justify-center">
-                        <div className="bg-slate-800/50 backdrop-blur-sm border border-slate-700/50 rounded-2xl p-4 group hover:border-slate-600/50 transition-colors duration-300">
-                          <div className="bg-black rounded-xl overflow-hidden w-72 mx-auto">
-                            <Image 
-                              src="/features/tactical-drawing-board.png" 
-                              alt="MatchOps Local tactical drawing interface showing orange tactical arrows and play diagrams drawn on soccer field"
-                              width={288}
-                              height={624}
-                              className="w-full h-auto block"
-                              style={{ imageRendering: 'crisp-edges' }}
-                            />
-                          </div>
-                          <p className="text-slate-300 text-xs mt-2 text-center font-body">{t('features.tactics.tacticalDrawing.caption')}</p>
-                        </div>
-                      </div>
-                    ) : feature.title === 'Competition Statistics' ? (
-                      <div className="flex justify-center">
-                        <div className="bg-slate-800/50 backdrop-blur-sm border border-slate-700/50 rounded-2xl p-4 group hover:border-slate-600/50 transition-colors duration-300">
-                          <div className="bg-black rounded-xl overflow-hidden w-72 mx-auto">
-                            <Image 
-                              src="/features/competition-statistics.png" 
-                              alt="MatchOps Local competition statistics showing EKK Kartteli 2025 team performance with 78.9% win rate and player statistics"
-                              width={288}
-                              height={624}
-                              className="w-full h-auto block"
-                              style={{ imageRendering: 'crisp-edges' }}
-                            />
-                          </div>
-                          <p className="text-slate-300 text-xs mt-2 text-center font-body">{t('features.statistics.competitionStats.caption')}</p>
-                        </div>
-                      </div>
-                    ) : feature.title === 'Player Performance Analysis' ? (
-                      <div className="flex justify-center">
-                        <div className="bg-slate-800/50 backdrop-blur-sm border border-slate-700/50 rounded-2xl p-4 group hover:border-slate-600/50 transition-colors duration-300">
-                          <div className="bg-black rounded-xl overflow-hidden w-72 mx-auto">
-                            <Image 
-                              src="/features/player-performance-analysis.png" 
-                              alt="MatchOps Local player performance analysis showing Jooa Pajala individual statistics with 47 matches, 38 goals, 16 assists and performance graphs"
-                              width={288}
-                              height={624}
-                              className="w-full h-auto block"
-                              style={{ imageRendering: 'crisp-edges' }}
-                            />
-                          </div>
-                          <p className="text-slate-300 text-xs mt-2 text-center font-body">{t('features.statistics.playerAnalysis.caption')}</p>
-                        </div>
-                      </div>
-                    ) : feature.title === 'Live Game Tracking' ? (
-                      <div className="flex justify-center">
-                        <div className="bg-slate-800/50 backdrop-blur-sm border border-slate-700/50 rounded-2xl p-4 group hover:border-slate-600/50 transition-colors duration-300">
-                          <div className="bg-black rounded-xl overflow-hidden w-72 mx-auto">
-                            <Image 
-                              src="/features/live-game-tracking.png" 
-                              alt="MatchOps Local live game tracking interface showing PePo Lila vs LaPa match with real-time timer at 02:16, live events, and action buttons"
-                              width={288}
-                              height={624}
-                              className="w-full h-auto block"
-                              style={{ imageRendering: 'crisp-edges' }}
-                            />
-                          </div>
-                          <p className="text-slate-300 text-xs mt-2 text-center font-body">{t('features.statistics.liveTracking.caption')}</p>
-                        </div>
-                      </div>
-                    ) : feature.title === 'Team & Roster Management' ? (
-                      <div className="flex justify-center">
-                        <div className="bg-slate-800/50 backdrop-blur-sm border border-slate-700/50 rounded-2xl p-4 group hover:border-slate-600/50 transition-colors duration-300">
-                          <div className="bg-black rounded-xl overflow-hidden w-72 mx-auto">
-                            <Image 
-                              src="/screenshots/team and roster management feature.png" 
-                              alt="MatchOps Local team and roster management interface showing player profiles with names, nicknames, jersey numbers and skill assessments"
-                              width={288}
-                              height={624}
-                              className="w-full h-auto block"
-                              style={{ imageRendering: 'crisp-edges' }}
-                            />
-                          </div>
-                          <p className="text-slate-300 text-xs mt-2 text-center font-body">{t('features.management.teamRoster.caption')}</p>
-                        </div>
-                      </div>
-                    ) : feature.title === 'Season & Tournament Management' ? (
-                      <div className="flex justify-center">
-                        <div className="bg-slate-800/50 backdrop-blur-sm border border-slate-700/50 rounded-2xl p-4 group hover:border-slate-600/50 transition-colors duration-300">
-                          <div className="bg-black rounded-xl overflow-hidden w-72 mx-auto">
-                            <Image 
-                              src="/screenshots/seasonandtournamentmanagement.png" 
-                              alt="MatchOps Local season and tournament management interface showing season creation, tournament setup and game organization"
-                              width={288}
-                              height={624}
-                              className="w-full h-auto block"
-                              style={{ imageRendering: 'crisp-edges' }}
-                            />
-                          </div>
-                          <p className="text-slate-300 text-xs mt-2 text-center font-body">{t('features.management.seasonTournament.caption')}</p>
-                        </div>
-                      </div>
-                    ) : feature.title === 'Save & Load Games' ? (
-                      <div className="flex justify-center">
-                        <div className="bg-slate-800/50 backdrop-blur-sm border border-slate-700/50 rounded-2xl p-4 group hover:border-slate-600/50 transition-colors duration-300">
-                          <div className="bg-black rounded-xl overflow-hidden w-72 mx-auto">
-                            <Image 
-                              src="/screenshots/Saver and load gamespng.png" 
-                              alt="MatchOps Local save and load games interface showing one-click saves, auto-resume and complete game state preservation"
-                              width={288}
-                              height={624}
-                              className="w-full h-auto block"
-                              style={{ imageRendering: 'crisp-edges' }}
-                            />
-                          </div>
-                          <p className="text-slate-300 text-xs mt-2 text-center font-body">{t('features.management.gameStorage.caption')}</p>
-                        </div>
-                      </div>
-                    ) : feature.title === 'Player Assessment & Rating System' ? (
-                      <div className="flex justify-center">
-                        <div className="bg-slate-800/50 backdrop-blur-sm border border-slate-700/50 rounded-2xl p-4 group hover:border-slate-600/50 transition-colors duration-300">
-                          <div className="bg-black rounded-xl overflow-hidden w-72 mx-auto">
-                            <Image 
-                              src="/screenshots/palyerassesments.png" 
-                              alt="MatchOps Local player assessment and rating system showing 10-skill evaluation with intensity, courage, technique ratings"
-                              width={288}
-                              height={624}
-                              className="w-full h-auto block"
-                              style={{ imageRendering: 'crisp-edges' }}
-                            />
-                          </div>
-                          <p className="text-slate-300 text-xs mt-2 text-center font-body">{t('features.management.playerAssessment.caption')}</p>
+                          <p className="text-slate-300 text-xs mt-2 text-center font-body">{t(feature.caption)}</p>
                         </div>
                       </div>
                     ) : (

--- a/src/locales/fi.ts
+++ b/src/locales/fi.ts
@@ -96,17 +96,17 @@ export default {
   // Features Page
   features: {
     title: 'Täydellinen ominaisuuskatsaus',
-    subtitle: 'Tutustu kaikkiin työkaluihin, jotka tekevät MatchOps Localista lopullisen valmennuskumppanin',
+    subtitle: 'Tutustu työkaluihin, joiden avulla MatchOps Local on valmentajan paras kumppani',
     categories: {
       tactics: 'Taktinen suunnittelu',
       statistics: 'Tilastot ja analytiikka',
       management: 'Joukkue- ja tiedonhallinta'
     },
     tactics: {
-      description: 'Suunnittele asetelmat, piirrä pelitaktiikat ja luo voittavia strategioita',
+      description: 'Suunnittele muodostelmat, piirrä pelit ja luo voittavat strategiat',
       playerPositioning: {
         title: 'Pelaajien sijoittelu',
-        description: 'Vedä ja pudota -pelaajien sijoittelu reaaliaikaisella muodostelman hallinnalla otteluiden aikana.',
+        description: 'Vedä ja pudota pelaajat paikoilleen ja hallitse muodostelmaa reaaliajassa ottelun aikana.',
         benefits: {
           0: 'Live-pelaajien sijoittelu',
           1: 'Reaaliaikaiset muodostelman päivitykset',
@@ -117,7 +117,7 @@ export default {
       },
       tacticalDrawing: {
         title: 'Taktinen piirustustaulu',
-        description: 'Interaktiiviset piirrostustyökalut taktisten pelien, nuolten ja strategisten kaavioiden luomiseen.',
+        description: 'Interaktiiviset työkalut pelitilanteiden, nuolien ja strategisten kaavioiden piirtämiseen.',
         benefits: {
           0: 'Piirrä taktisia viivoja ja nuolia',
           1: 'Luo vakiotilanteiden pelejä',
@@ -128,10 +128,10 @@ export default {
       }
     },
     statistics: {
-      description: 'Seuraa suorituskykyä yksityiskohtaisella analytiikalla ja raportoinnilla',
+      description: 'Seuraa suorituskykyä tarkalla analytiikalla ja raporteilla',
       competitionStats: {
         title: 'Kilpailutilastot',
-        description: 'Seuraa joukkueen suorituskykyä kausiensa, turnausten ja kilpailujen yli.',
+        description: 'Seuraa joukkueesi suoritusta kausissa, turnauksissa ja kilpailuissa.',
         benefits: {
           0: 'Kilpailun yleiskatsausdata',
           1: 'Turnaus- ja kausiseuranta',
@@ -142,7 +142,7 @@ export default {
       },
       playerAnalysis: {
         title: 'Pelaajan suorituskyvyn analyysi',
-        description: 'Yksityiskohtaiset yksilöllisten pelaajien tilastot ja kehityksen seuranta.',
+        description: 'Yksityiskohtaiset pelaajatilastot ja kehityksen seuranta.',
         benefits: {
           0: 'Yksilölliset pelaajametriikat',
           1: 'Henkilökohtaisen kehityksen seuranta',
@@ -153,7 +153,7 @@ export default {
       },
       liveTracking: {
         title: 'Live-pelin seuranta',
-        description: 'Reaaliaikainen tapahtumien seuranta otteluiden aikana välittömillä tilastopäivityksillä ja älykkäällä vaihtojenhallinnalla.',
+        description: 'Reaaliaikainen tapahtumaseuranta tilastopäivityksillä ja älykkäällä vaihtojen hallinnalla.',
         benefits: {
           0: 'Live-tapahtumien kirjaus - Tallenna maalit, rikkomukset ja ottelutapahtumat reaaliajassa',
           1: 'Reaaliaikaiset tilastot - Välittömät tilastopäivitykset ja ottelukellon seuranta',
@@ -164,10 +164,10 @@ export default {
       }
     },
     management: {
-      description: 'Organisoi joukkueet, hallitse dataa ja koordinoi valmentamistyönkulkuasi',
+      description: 'Organisoi joukkueesi, hallitse dataa ja koordinoi valmennustyönkulkuasi',
       teamRoster: {
         title: 'Joukkue- ja kokoonpanon hallinta',
-        description: 'Rakenna ja organisoi joukkuekokoonpano yksityiskohtaisilla pelaajaprofiilit ja suorituskyvyn seurannalla.',
+        description: 'Rakenna ja hallitse kokoonpanoa yksityiskohtaisten pelaajaprofiilien ja suorituskyvyn seurannan avulla.',
         benefits: {
           0: 'Pelaajaprofiilit - Nimet, lempinimet, pelipaidat ja muistiinpanot',
           1: 'Monitiimi-tuki - Hallitse useita joukkueita samanaikaisesti',
@@ -178,7 +178,7 @@ export default {
       },
       seasonTournament: {
         title: 'Kausi- ja turnaushallinta',
-        description: 'Luo kausia ja turnauksia järjestääksesi pelejäsi ja seurataksesi suorituskykyä ajan mittaan.',
+        description: 'Luo kausia ja turnauksia pelien organisointiin ja seurantaan.',
         benefits: {
           0: 'Kauden luominen - Aseta kausia päivämäärineen ja sijainteineen',
           1: 'Turnauksen perustaminen - Luo turnauksia ikäryhmille ja tasoille',
@@ -189,7 +189,7 @@ export default {
       },
       gameStorage: {
         title: 'Tallenna ja lataa pelit',
-        description: 'Tallenna täydelliset otteluistunnot paikallisesti ja lataa ne milloin tahansa tarkastelua tai pelin jatkamista varten.',
+        description: 'Tallenna ottelut paikallisesti ja palauta ne milloin tahansa tarkasteluun tai jatkamiseen.',
         benefits: {
           0: 'Yhden klikkauksen tallennukset - Tallenna nykyinen pelitila välittömästi',
           1: 'Automaattinen jatko - Jatka automaattisesti viimeistä peliistuntoasi',
@@ -200,7 +200,7 @@ export default {
       },
       playerAssessment: {
         title: 'Pelaaja-arviointi ja -luokitusjärjestelmä',
-        description: '10-taidon pelaaja-arviointijärjestelmä kattavalla luokituksella ja kehityksen seurannalla.',
+        description: 'Pelaaja-arviointi kymmenen taitokategorian ja kehityksen seurannan avulla.',
         benefits: {
           0: '10-taidon pelaaja-arviointijärjestelmä (intensiteetti, rohkeus, tekniikka, luovuus jne.)',
           1: 'Kokonaispelaaja-arvioinnit 1-10 asteikolla',


### PR DESCRIPTION
## Summary
- render feature screenshots using data so localization works
- polish Finnish feature descriptions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bdb115bf70832c8aabe8b3755b7eed